### PR TITLE
Support for default values in objects

### DIFF
--- a/src/toJSONSchema/index.spec.ts
+++ b/src/toJSONSchema/index.spec.ts
@@ -45,7 +45,7 @@ function testCase(
         // Schema converted properly
         const convertedSchema = toJSONSchema({ schema, ...options });
         if (jsonSchema)
-            expect(convertedSchema).toEqual(jsonSchema);
+            expect(jsonSchema).toEqual(convertedSchema);
         const ajv = new Ajv();
         addFormats(ajv);
         const jsonValidator = ajv.compile(convertedSchema!);
@@ -311,6 +311,63 @@ describe('object', () => {
             { string: 'foo', unknown: 'property' },
             { optionalString: 'foo' },
             { string: 'foo', optionalString: 1 },
+            ...SAMPLE_VALUES,
+        ],
+    }));
+
+    it('should add default values from object with optional fields', testCase({
+        schema: v.object({ string: v.string(), optionalString: v.optional(v.string(), 'optional') }),
+        jsonSchema: {
+            $schema,
+            type: 'object',
+            properties: { string: { type: 'string' }, optionalString: { type: 'string', default: 'optional' } },
+            required: ['string'],
+        },
+        validValues: [
+            { string: 'foo', unknown: 'property' },
+            { string: 'foo', optionalString: 'foo' },
+        ],
+        invalidValues: [
+            { optionalString: 'foo' },
+            { string: 'foo', optionalString: 1 },
+            ...SAMPLE_VALUES,
+        ],
+    }));
+
+    it('should add default values from object with nullable fields', testCase({
+        schema: v.object({ string: v.string(), nullableString: v.nullable(v.string(), 'nullable') }),
+        jsonSchema: {
+            $schema,
+            type: 'object',
+            properties: { string: { type: 'string' }, nullableString: {anyOf: [{ const: null }, { type: 'string' }], default: 'nullable'} },
+            required: ['string', 'nullableString'],
+        },
+        validValues: [
+            { string: 'foo', nullableString: 'foo' },
+            { string: 'foo', nullableString: 'foo', unknown: 'property' },
+        ],
+        invalidValues: [
+            { nullableString: 'foo' },
+            { string: 'foo', nullableString: 1 },
+            ...SAMPLE_VALUES,
+        ],
+    }));
+
+    it('should add default values from object with a nullish field', testCase({
+        schema: v.object({ string: v.string(), nullishString: v.nullish(v.string(), 'nullish') }),
+        jsonSchema: {
+            $schema,
+            type: 'object',
+            properties: { string: { type: 'string' }, nullishString: {anyOf: [{ const: null }, { type: 'string' }], default: 'nullish'} },
+            required: ['string'],
+        },
+        validValues: [
+            { string: 'foo', nullishString: 'foo' },
+            { string: 'foo', unknown: 'property' },
+        ],
+        invalidValues: [
+            { nullishString: 'foo' },
+            { string: 'foo', nullishString: 1 },
             ...SAMPLE_VALUES,
         ],
     }));

--- a/src/toJSONSchema/schemas.ts
+++ b/src/toJSONSchema/schemas.ts
@@ -1,4 +1,5 @@
 import {
+    getDefault,
     AnySchema,
     ArraySchema,
     BooleanSchema,
@@ -14,10 +15,11 @@ import {
     StringSchema,
     TupleSchema,
     UnionSchema,
+    NullishSchema,
 } from 'valibot';
 import { assertJSONLiteral } from '../utils/json-schema';
 import { JSONSchema7 } from 'json-schema';
-import { isNeverSchema, isOptionalSchema, isStringSchema } from '../utils/valibot';
+import { isNeverSchema, isNullishSchema, isOptionalSchema, isStringSchema } from '../utils/valibot';
 import { isEqual } from '../utils/isEqual';
 import { assert } from '../utils/assert';
 import { BaseConverter, Context } from './types';
@@ -39,7 +41,8 @@ export type SupportedSchemas =
     | IntersectSchema<any>
     | UnionSchema<any>
     | PicklistSchema<any>
-    | RecursiveSchema<any>;
+    | RecursiveSchema<any>
+    | NullishSchema<any>;
 
 type SchemaConverter<S extends SupportedSchemas> = (schema: S, convert: BaseConverter, context: Context) => JSONSchema7;
 
@@ -56,6 +59,7 @@ export const SCHEMA_CONVERTERS: {
     string: () => ({ type: 'string' }),
     boolean: () => ({ type: 'boolean' }),
     // Compositions
+    nullish: ({ wrapped }, convert) => ({ anyOf: [{ const: null }, convert(wrapped)] }),
     nullable: ({ wrapped }, convert) => ({ anyOf: [{ const: null }, convert(wrapped)] }),
     picklist: ({ options }) => ({ enum: options.map(assertJSONLiteral) }),
     union: ({ options }, convert) => ({ anyOf: options.map(convert) }),
@@ -85,12 +89,16 @@ export const SCHEMA_CONVERTERS: {
         const required: string[] = [];
         for (const [propKey, propValue] of Object.entries(entries)) {
             let propSchema = propValue as any;
+            let defaultValue : unknown = getDefault(propSchema);
             if (isOptionalSchema(propSchema)) {
                 propSchema = propSchema.wrapped;
-            } else {
+                // One extra check for optional(nullable(...))
+                if(defaultValue === undefined) defaultValue = getDefault(propSchema);
+            } else if(!isNullishSchema(propSchema)) {
                 required.push(propKey);
             }
             properties[propKey] = convert(propSchema)!;
+            if(defaultValue !== undefined) properties[propKey].default = defaultValue;
             assignExtraJSONSchemaFeatures(propValue as any, properties[propKey]);
         }
         let additionalProperties: JSONSchema7['additionalProperties'];
@@ -99,7 +107,10 @@ export const SCHEMA_CONVERTERS: {
         } else if (context.strictObjectTypes) {
             additionalProperties = false;
         }
-        return { type: 'object', properties, required: required.length ? required : undefined, additionalProperties };
+        const output : JSONSchema7 = { type: 'object', properties, required: required.length ? required : undefined };
+        if(additionalProperties !== undefined) output.additionalProperties = additionalProperties;
+
+        return output;
     },
     record({ key, value }, convert) {
         assert(key, isStringSchema, 'Unsupported record key type: %');

--- a/src/toJSONSchema/schemas.ts
+++ b/src/toJSONSchema/schemas.ts
@@ -119,8 +119,9 @@ export const SCHEMA_CONVERTERS: {
         } else if (context.strictObjectTypes) {
             additionalProperties = false;
         }
-        const output : JSONSchema7 = { type: 'object', properties, required: required.length ? required : undefined };
+        const output : JSONSchema7 = { type: 'object', properties };
         if(additionalProperties !== undefined) output.additionalProperties = additionalProperties;
+        if(required.length) output.required = required;
 
         return output;
     },

--- a/src/utils/valibot.ts
+++ b/src/utils/valibot.ts
@@ -4,13 +4,14 @@ export function isSchema(schema: any): boolean {
     return schema?.type;
 }
 
-type KnownSchemas = v.OptionalSchema<any> | v.StringSchema | v.NeverSchema;
+type KnownSchemas = v.OptionalSchema<any> | v.StringSchema | v.NeverSchema | v.NullishSchema<any>;
 type GetSchema<T extends string> = Extract<KnownSchemas, { type: T }>
 
 export const isSchemaType = <T extends KnownSchemas['type']>(type: T) => {
     return (schema: any): schema is GetSchema<T> => !!schema && schema.type === type;
 };
 
+export const isNullishSchema = isSchemaType('nullish');
 export const isOptionalSchema = isSchemaType('optional');
 export const isStringSchema = isSchemaType('string');
 export const isNeverSchema = isSchemaType('never');


### PR DESCRIPTION
This adds default values for `optional`, `nullable` and `nullish` in validators, as in:

```ts
const schema = object({
  name: v.optional(v.string(), 'New user') })
})
```

```ts
{
  '$schema': 'http://json-schema.org/draft-07/schema#',
  type: 'object',
  properties: { name: { type: 'string', default: 'New user' } }
}
```