### PR TITLE
Basic support for date converter

### DIFF
--- a/src/toJSONSchema/index.spec.ts
+++ b/src/toJSONSchema/index.spec.ts
@@ -479,7 +479,7 @@ describe('composition types', () => {
     });
 });
 
-describe.only('date', () => {
+describe('date', () => {
     it('should be able to use the "integer" strategy', testCase({
         schema: v.date(),
         jsonSchema: {

--- a/src/toJSONSchema/index.spec.ts
+++ b/src/toJSONSchema/index.spec.ts
@@ -501,6 +501,10 @@ describe.only('date', () => {
         invalidValues: SAMPLE_VALUES.filter(v => typeof v !== 'string'),
         options: { dateStrategy: 'string' }
     }))
+
+    it('should throw an error if the dateStrategy option isn\'t defined and a date validator exists', () => {
+        expect(testCase({ schema: v.date() })).toThrow(Error)
+    })
 })
 
 describe('recursive type', () => {

--- a/src/toJSONSchema/schemas.ts
+++ b/src/toJSONSchema/schemas.ts
@@ -2,6 +2,7 @@ import {
     AnySchema,
     ArraySchema,
     BooleanSchema,
+    DateSchema,
     IntersectSchema,
     LiteralSchema,
     NullableSchema,
@@ -39,7 +40,8 @@ export type SupportedSchemas =
     | IntersectSchema<any>
     | UnionSchema<any>
     | PicklistSchema<any>
-    | RecursiveSchema<any>;
+    | RecursiveSchema<any>
+    | DateSchema;
 
 type SchemaConverter<S extends SupportedSchemas> = (schema: S, convert: BaseConverter, context: Context) => JSONSchema7;
 
@@ -113,4 +115,14 @@ export const SCHEMA_CONVERTERS: {
         }
         return { $ref: toDefinitionURI(defName) };
     },
+    date(_, __, context) {
+        if(!context.dateStrategy) {
+            throw new Error('The "dateStrategy" option must be set to handle date validators');
+        }
+
+        switch(context.dateStrategy) {
+            case 'integer': return { type: 'integer', format: 'unix-time' }
+            case 'string': return { type: 'string', format: 'date-time' }
+        }
+    }
 };

--- a/src/toJSONSchema/types.ts
+++ b/src/toJSONSchema/types.ts
@@ -13,7 +13,13 @@ export interface Options {
     /**
      * Make all object type strict (`additionalProperties: false`).
      */
-    strictObjectTypes?: boolean
+    strictObjectTypes?: boolean,
+    /**
+     * Date output:
+     * 'integer' sets the type to 'integer' and format to 'unix-time'.
+     * 'string' sets the type to 'string' and format to 'date-time'.
+     */
+    dateStrategy?: 'string' | 'integer'
 }
 
 export interface Context {
@@ -25,6 +31,10 @@ export interface Context {
      * Activate strict object types
      */
     strictObjectTypes?: Options['strictObjectTypes'];
+    /**
+     * Current date strategy
+     */
+    dateStrategy?: Options['dateStrategy']
 }
 
 export type DefinitionNameMap = Map<SupportedSchemas, string>;


### PR DESCRIPTION
Date output works, with a "dateStrategy" option to output different formats. (Let me know if it should be renamed.)

When #4 is merged, I can extend this to convert the eventual default value to its correct output format, so this will work:

```ts
const schema = optional(date(), new Date('2024-01-22'))
const jsonSchema = toJSONSchema({
  schema,
  dateStrategy: 'integer'
})
```

```ts
{
  type: 'integer',
  format: 'unix-time',
  default: 1705878000
}
```
