### PR TITLE
Moduleresolution future-proofing

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,12 +1,12 @@
-import fs from 'fs';
-import path from 'path';
 import { Command, Option } from 'commander';
+import fs from 'fs';
 import get from 'lodash/get';
+import path from 'path';
 import stableStringify from 'safe-stable-stringify';
 
-import { toJSONSchema } from '../src';
-import { DateStrategy } from '../src/toJSONSchema/types';
-import { isSchema } from '../src/utils/valibot';
+import { toJSONSchema } from '../src/index.js';
+import { DateStrategy } from '../src/toJSONSchema/types.js';
+import { isSchema } from '../src/utils/valibot.js';
 
 const program = new Command();
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,9 +1,9 @@
-import { Command, Option } from 'commander';
 import fs from 'fs';
 import get from 'lodash/get';
 import path from 'path';
 import stableStringify from 'safe-stable-stringify';
 
+import { Command, Option } from 'commander';
 import { toJSONSchema } from '../src/index.js';
 import { DateStrategy } from '../src/toJSONSchema/types.js';
 import { isSchema } from '../src/utils/valibot.js';

--- a/src/extension/assignExtraJSONSchemaFeatures.ts
+++ b/src/extension/assignExtraJSONSchemaFeatures.ts
@@ -1,6 +1,6 @@
 import { JSONSchema7 } from 'json-schema';
-import { SupportedSchemas } from '../toJSONSchema/schemas';
-import { getJSONSchemaFeatures } from './withJSONSchemaFeatures';
+import { SupportedSchemas } from '../toJSONSchema/schemas.js';
+import { getJSONSchemaFeatures } from './withJSONSchemaFeatures.js';
 
 export function assignExtraJSONSchemaFeatures(schema: SupportedSchemas, converted: JSONSchema7) {
     const jsonSchemaFeatures = getJSONSchemaFeatures(schema as any);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { toJSONSchema } from './toJSONSchema';
-export { ToJSONSchemaOptions } from './toJSONSchema/types';
-export { withJSONSchemaFeatures } from './extension/withJSONSchemaFeatures';
+export { withJSONSchemaFeatures } from './extension/withJSONSchemaFeatures.js';
+export { toJSONSchema } from './toJSONSchema/index.js';
+export { ToJSONSchemaOptions } from './toJSONSchema/types.js';

--- a/src/toJSONSchema/index.spec.ts
+++ b/src/toJSONSchema/index.spec.ts
@@ -9,11 +9,11 @@ import * as v from 'valibot';
 import { describe, expect, it } from 'vitest';
 
 import { toJSONSchema } from '.';
-import { withJSONSchemaFeatures } from '../extension/withJSONSchemaFeatures';
-import { $schema } from '../utils/json-schema';
-import { and, negate } from '../utils/predicate';
-import { SupportedSchemas } from './schemas';
-import { ToJSONSchemaOptions } from './types';
+import { withJSONSchemaFeatures } from '../extension/withJSONSchemaFeatures.js';
+import { $schema } from '../utils/json-schema.js';
+import { and, negate } from '../utils/predicate.js';
+import { SupportedSchemas } from './schemas.js';
+import { ToJSONSchemaOptions } from './types.js';
 
 const emptyObject = {} as const;
 const emptyArray = [] as const;

--- a/src/toJSONSchema/index.ts
+++ b/src/toJSONSchema/index.ts
@@ -1,11 +1,11 @@
 import { type JSONSchema7 } from 'json-schema';
-import { assignExtraJSONSchemaFeatures } from '../extension/assignExtraJSONSchemaFeatures';
-import { assert } from '../utils/assert';
-import { $schema } from '../utils/json-schema';
-import { SCHEMA_CONVERTERS, SupportedSchemas } from './schemas';
+import { assignExtraJSONSchemaFeatures } from '../extension/assignExtraJSONSchemaFeatures.js';
+import { assert } from '../utils/assert.js';
+import { $schema } from '../utils/json-schema.js';
+import { SCHEMA_CONVERTERS, SupportedSchemas } from './schemas.js';
 import { toDefinitionURI } from './toDefinitionURI';
-import { Context, DefinitionNameMap, ToJSONSchemaOptions } from './types';
-import { convertPipe } from './validations';
+import { Context, DefinitionNameMap, ToJSONSchemaOptions } from './types.js';
+import { convertPipe } from './validations.js';
 
 function getDefNameMap(definitions: ToJSONSchemaOptions['definitions'] = {}) {
     const map: DefinitionNameMap = new Map();

--- a/src/toJSONSchema/schemas.ts
+++ b/src/toJSONSchema/schemas.ts
@@ -20,13 +20,13 @@ import {
     UnionSchema,
     getDefault,
 } from 'valibot';
-import { assignExtraJSONSchemaFeatures } from '../extension/assignExtraJSONSchemaFeatures';
-import { assert } from '../utils/assert';
-import { isEqual } from '../utils/isEqual';
-import { assertJSONLiteral } from '../utils/json-schema';
-import { isNeverSchema, isNullishSchema, isOptionalSchema, isStringSchema } from '../utils/valibot';
-import { toDefinitionURI } from './toDefinitionURI';
-import { BaseConverter, Context } from './types';
+import { assignExtraJSONSchemaFeatures } from '../extension/assignExtraJSONSchemaFeatures.js';
+import { assert } from '../utils/assert.js';
+import { isEqual } from '../utils/isEqual.js';
+import { assertJSONLiteral } from '../utils/json-schema.js';
+import { isNeverSchema, isNullishSchema, isOptionalSchema, isStringSchema } from '../utils/valibot.js';
+import { toDefinitionURI } from './toDefinitionURI.js';
+import { BaseConverter, Context } from './types.js';
 
 export type SupportedSchemas =
     | AnySchema

--- a/src/toJSONSchema/types.ts
+++ b/src/toJSONSchema/types.ts
@@ -1,7 +1,7 @@
 import { JSONSchema7 } from 'json-schema';
 import { BaseSchema, BaseSchemaAsync } from 'valibot';
-import { ValueOf } from '../utils/ValueOf';
-import { SupportedSchemas } from './schemas';
+import { ValueOf } from '../utils/ValueOf.js';
+import { SupportedSchemas } from './schemas.js';
 
 export const DateStrategy = {
     string: 'string',

--- a/src/toJSONSchema/validations.ts
+++ b/src/toJSONSchema/validations.ts
@@ -17,8 +17,8 @@ import {
     UuidValidation,
     ValueValidation,
 } from 'valibot';
-import { assert } from '../utils/assert';
-import { SupportedSchemas } from './schemas';
+import { assert } from '../utils/assert.js';
+import { SupportedSchemas } from './schemas.js';
 
 export type SupportedValidation =
     | LengthValidation<any, any>

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,4 +1,4 @@
-import type { Predicate } from './predicate';
+import type { Predicate } from './predicate.js';
 
 export function assert<V>(value: V, predicate: Predicate<V>, message: string) {
     if (!predicate(value)) throw new Error(message.replace('%', String(value)));

--- a/src/utils/isEqual.spec.ts
+++ b/src/utils/isEqual.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { isEqual } from './isEqual';
+import { isEqual } from './isEqual.js';
 
 test(isEqual, () => {
     expect(isEqual('', '')).toBe(true);

--- a/src/utils/json-schema.ts
+++ b/src/utils/json-schema.ts
@@ -1,4 +1,4 @@
-import { assert } from './assert';
+import { assert } from './assert.js';
 
 /** JSON Schema URI */
 export const $schema = 'http://json-schema.org/draft-07/schema#';


### PR DESCRIPTION
Some bundlers need file extensions to be able to find the imports. The common solution for best support is to add extensions to all imports. It won't affect anything else, and is good for the future.

TS setting: https://www.typescriptlang.org/tsconfig#moduleResolution
