### PR TITLE
Support for minValue, maxValue and value in date validation.

### DIFF
--- a/src/toJSONSchema/index.spec.ts
+++ b/src/toJSONSchema/index.spec.ts
@@ -803,6 +803,46 @@ describe('date', () => {
     it("should throw an error if the dateStrategy option isn't defined and a date validator exists", () => {
         expect(testCase({ schema: v.date() })).toThrow(Error);
     });
+
+    it(
+        'should add date constraints to date fields',
+        testCase({
+            schema: v.object({
+                date: v.date([v.minValue(new Date('2024-03-25')), v.maxValue(new Date('2024-03-26'))]),
+                exact: v.date([v.value(new Date('2024-03-27'))]),
+            }),
+            jsonSchema: {
+                $schema,
+                properties: {
+                    date: {
+                        format: 'unix-time',
+                        type: 'integer',
+                        maximum: 1711411200000,
+                        minimum: 1711324800000,
+                    },
+                    exact: {
+                        format: 'unix-time',
+                        type: 'integer',
+                        maximum: 1711497600000,
+                        minimum: 1711497600000,
+                    },
+                },
+                required: ['date', 'exact'],
+                type: 'object',
+            },
+            validValues: [
+                { date: new Date('2024-03-25'), exact: new Date('2024-03-27') },
+                { date: new Date('2024-03-26'), exact: new Date('2024-03-27') },
+            ],
+            invalidValues: [
+                { date: 'no date', exact: new Date('2024-03-27') },
+                { date: new Date('2024-03-22'), exact: new Date('2024-03-27') },
+                { date: new Date('2024-03-25'), exact: new Date('2024-03-29') },
+            ],
+            options: { dateStrategy: 'integer' },
+            hasDates: true,
+        }),
+    );
 });
 
 describe('undefined_', () => {

--- a/src/toJSONSchema/validations.ts
+++ b/src/toJSONSchema/validations.ts
@@ -1,5 +1,5 @@
-import { JSONSchema7 } from 'json-schema';
-import {
+import type { JSONSchema7 } from 'json-schema';
+import type {
     EmailValidation,
     IntegerValidation,
     Ipv4Validation,
@@ -18,7 +18,7 @@ import {
     ValueValidation,
 } from 'valibot';
 import { assert } from '../utils/assert';
-import { SupportedSchemas } from './schemas';
+import type { SupportedSchemas } from './schemas';
 
 export type SupportedValidation =
     | LengthValidation<any, any>
@@ -72,6 +72,20 @@ const VALIDATION_BY_SCHEMA: {
     },
     boolean: {
         value: ({ requirement }) => ({ const: requirement }),
+    },
+    date: {
+        min_value: ({ requirement }) => {
+            assert(requirement, (r) => r instanceof Date, 'Non-date value used for minValue validation');
+            return { minimum: requirement.getTime() };
+        },
+        max_value: ({ requirement }) => {
+            assert(requirement, (r) => r instanceof Date, 'Non-date value used for maxValue validation');
+            return { maximum: requirement.getTime() };
+        },
+        value: ({ requirement }) => {
+            assert(requirement, (r) => r instanceof Date, 'Non-date value used for value validation');
+            return { minimum: requirement.getTime(), maximum: requirement.getTime() };
+        },
     },
 };
 


### PR DESCRIPTION
I couldn't find a way to access the context in the validation functions, to prevent it being used when dateStrategy is not `'integer'`, but on the other hand, a min/max timestamp range is the only validation that seems feasible for dates.